### PR TITLE
Free attributes memory after tag creation

### DIFF
--- a/lib/libplctag_tag.c
+++ b/lib/libplctag_tag.c
@@ -76,9 +76,15 @@ LIB_EXPORT plc_tag plc_tag_create(const char *attrib_str)
      */
     tag = ab_tag_create(attribs);
 
-    if(!tag) {
-        return tag;
-    }
+    /*
+     * Release memory for attributes
+     *
+     * some code is commented out that would have kept a pointer
+     * to the attributes in the tag and released the memory upon
+     * tag destruction. To prevent a memory leak without maintaining
+     * that pointer, the memory needs to be released here.
+     */
+     attr_destroy(attribs);
 
     return tag;
 }


### PR DESCRIPTION
In plc_tag_create, a call to attr_create_from_str allocates memory
that is passed to ab_tag_create, but then no longer used or referenced.
Added attr_destroy call after the return of ab_tag_create to free
memory.

Also, removed if-statement as it does not appear to do anything.
