### PR TITLE
Pass through status in plc_tag_status

### DIFF
--- a/lib/libplctag_tag.c
+++ b/lib/libplctag_tag.c
@@ -267,6 +267,11 @@ LIB_EXPORT int plc_tag_status(plc_tag tag)
         return PLCTAG_ERR_NULL_PTR;
 
     if(!tag->vtable || !tag->vtable->status) {
+        if(tag->status) {
+            pdebug(tag->debug, "tag status not ok!");
+            return tag->status;
+        }
+
         pdebug(tag->debug, "tag status accessor not defined!");
         tag->status = PLCTAG_ERR_NOT_IMPLEMENTED;
         return PLCTAG_ERR_NOT_IMPLEMENTED;


### PR DESCRIPTION
Previously only returned PLCTAG_ERR_NOT_IMPLEMENTED
in plc_tag_status if the tag->vtable or tag->vtable->status
were false. This resulted in many different errors being
hidden behind one error code.

Added code where when the above condition occurs, the tag->status
will be passed through if it is non-zero.
