### PR TITLE
Fix possible null dereferences found by cppcheck

### DIFF
--- a/lib/ab/ab_common.c
+++ b/lib/ab/ab_common.c
@@ -364,15 +364,16 @@ int ab_tag_abort(ab_tag_p tag)
 int ab_tag_destroy(ab_tag_p tag)
 {
     int rc = PLCTAG_STATUS_OK;
+
+    /* already destroyed? */
+    if (!tag)
+        return rc;
+
     ab_connection_p connection = tag->connection;
     ab_session_p session = tag->session;
     int debug = tag->debug;
 
     pdebug(debug, "Starting.");
-
-    /* already destroyed? */
-    if (!tag)
-        return rc;
 
     /*
      * stop any current actions. Note that we

--- a/lib/ab/connection.c
+++ b/lib/ab/connection.c
@@ -340,9 +340,9 @@ int connection_add_tag_unsafe(ab_connection_p connection, ab_tag_p tag)
 int connection_add_tag(ab_connection_p connection, ab_tag_p tag)
 {
     int rc = PLCTAG_STATUS_OK;
-    int debug = connection->debug;
 
     if(connection) {
+        int debug = connection->debug;
         pdebug(debug,"entering critical block %p",global_session_mut);
         critical_block(global_session_mut) {
             rc = connection_add_tag_unsafe(connection, tag);
@@ -396,9 +396,9 @@ int connection_remove_tag_unsafe(ab_connection_p connection, ab_tag_p tag)
 int connection_remove_tag(ab_connection_p connection, ab_tag_p tag)
 {
     int rc = PLCTAG_STATUS_OK;
-    int debug = connection->debug;
 
     if(connection && connection->session) {
+        int debug = connection->debug;
         pdebug(debug,"entering critical block %p",global_session_mut);
         critical_block(global_session_mut) {
             rc = connection_remove_tag_unsafe(connection, tag);
@@ -435,13 +435,13 @@ int connection_is_empty(ab_connection_p connection)
 
 int connection_destroy_unsafe(ab_connection_p connection)
 {
-    int debug = connection->debug;
-
-    pdebug(debug, "Starting.");
-
     if (!connection) {
         return 1;
     }
+
+    int debug = connection->debug;
+
+    pdebug(debug, "Starting.");
 
     /* do not destroy the connection if there are
      * connections still */

--- a/lib/ab/pccc.c
+++ b/lib/ab/pccc.c
@@ -80,11 +80,11 @@ int pccc_encode_tag_name(uint8_t *data, int *size, const char *name, int max_tag
 	const char *tmp = name;
 	uint8_t *level_byte = data;
 
-	*size = 0;
-
 	if(!data || !size || !name) {
 		return 0;
 	}
+
+	*size = 0;
 
 	if(!strlen(name)) {
 		return 0;

--- a/lib/ab/session.c
+++ b/lib/ab/session.c
@@ -99,19 +99,17 @@ int session_add_connection(ab_session_p session, ab_connection_p connection)
 {
     int rc = PLCTAG_STATUS_OK;
 
-    pdebug(session->debug, "Starting");
-
     if(session) {
+        pdebug(session->debug, "Starting");
         pdebug(session->debug,"entering critical block %p",global_session_mut);
         critical_block(global_session_mut) {
             rc = session_add_connection_unsafe(session, connection);
         }
         pdebug(session->debug,"leaving critical block %p", global_session_mut);
+        pdebug(session->debug, "Done");
     } else {
         rc = PLCTAG_ERR_NULL_PTR;
     }
-
-    pdebug(session->debug, "Done");
 
     return rc;
 }
@@ -160,19 +158,17 @@ int session_remove_connection(ab_session_p session, ab_connection_p connection)
 {
     int rc = PLCTAG_STATUS_OK;
 
-    pdebug(session->debug, "Starting");
-
     if(session) {
+        pdebug(session->debug, "Starting");
         pdebug(session->debug,"entering critical block %p", global_session_mut);
         critical_block(global_session_mut) {
             rc = session_remove_connection_unsafe(session, connection);
         }
         pdebug(session->debug,"leaving critical block %p", global_session_mut);
+        pdebug(session->debug, "Done");
     } else {
         rc = PLCTAG_ERR_NULL_PTR;
     }
-
-    pdebug(session->debug, "Done");
 
     return rc;
 }
@@ -259,10 +255,10 @@ int remove_session_unsafe(ab_session_p n)
 {
     ab_session_p tmp;
 
-    pdebug(n->debug, "Starting");
-
     if (!n || !sessions)
         return 0;
+
+    pdebug(n->debug, "Starting");
 
     tmp = sessions;
 
@@ -490,13 +486,13 @@ int session_connect(ab_session_p session, const char* host)
 /* must have the session mutex held here */
 int session_destroy_unsafe(ab_session_p session)
 {
+    if (!session)
+        return 1;
+
     int debug = session->debug;
     ab_request_p req;
 
     pdebug(debug, "Starting.");
-
-    if (!session)
-        return 1;
 
     /* do not destroy the session if there are
      * tags or connections still */

--- a/lib/libplctag_tag.c
+++ b/lib/libplctag_tag.c
@@ -120,12 +120,12 @@ LIB_EXPORT plc_tag plc_tag_create(const char *attrib_str)
 
 LIB_EXPORT int plc_tag_lock(plc_tag tag)
 {
+	if(!tag || !tag->mut)
+		return PLCTAG_ERR_NULL_PTR;
+
 	int debug = tag->debug;
 
 	pdebug(debug, "Starting.");
-
-	if(!tag || !tag->mut)
-		return PLCTAG_ERR_NULL_PTR;
 
 	/* lock the mutex */
 	tag->status = mutex_lock(tag->mut);
@@ -147,12 +147,12 @@ LIB_EXPORT int plc_tag_lock(plc_tag tag)
 
 LIB_EXPORT int plc_tag_unlock(plc_tag tag)
 {
+	if(!tag || !tag->mut)
+		return PLCTAG_ERR_NULL_PTR;
+
 	int debug = tag->debug;
 
 	pdebug(debug, "Starting.");
-
-	if(!tag || !tag->mut)
-		return PLCTAG_ERR_NULL_PTR;
 
 	/* unlock the mutex */
 	tag->status = mutex_unlock(tag->mut);
@@ -179,12 +179,12 @@ LIB_EXPORT int plc_tag_unlock(plc_tag tag)
 
 LIB_EXPORT int plc_tag_abort(plc_tag tag)
 {
+	if(!tag || !tag->vtable)
+		return PLCTAG_ERR_NULL_PTR;
+
 	int debug = tag->debug;
 
 	pdebug(debug, "Starting.");
-
-	if(!tag || !tag->vtable)
-		return PLCTAG_ERR_NULL_PTR;
 
 	/* clear the status */
 	tag->status = PLCTAG_STATUS_OK;
@@ -221,14 +221,14 @@ LIB_EXPORT int plc_tag_abort(plc_tag tag)
 
 LIB_EXPORT int plc_tag_destroy(plc_tag tag)
 {
+	if(!tag)
+		return PLCTAG_STATUS_OK;
+
 	int debug = tag->debug;
 	mutex_p temp_mut;
 	int rc = PLCTAG_STATUS_OK;
 
 	pdebug(debug, "Starting.");
-
-	if(!tag)
-		return PLCTAG_STATUS_OK;
 
 	/* clear the mutex */
 	if(tag->mut) {
@@ -271,13 +271,13 @@ LIB_EXPORT int plc_tag_destroy(plc_tag tag)
 
 LIB_EXPORT int plc_tag_read(plc_tag tag, int timeout)
 {
+	if(!tag)
+		return PLCTAG_ERR_NULL_PTR;
+
 	int debug = tag->debug;
 	int rc;
 
 	pdebug(debug, "Starting.");
-
-	if(!tag)
-		return PLCTAG_ERR_NULL_PTR;
 
 	/* check for null parts */
 	if(!tag->vtable || !tag->vtable->read) {
@@ -406,14 +406,13 @@ LIB_EXPORT int plc_tag_status(plc_tag tag)
 
 LIB_EXPORT int plc_tag_write(plc_tag tag, int timeout)
 {
+	if(!tag)
+		return PLCTAG_ERR_NULL_PTR;
+
 	int debug = tag->debug;
 	int rc;
 
 	pdebug(debug, "Starting.");
-
-	if(!tag) {
-		return PLCTAG_ERR_NULL_PTR;
-	}
 
 	/* we are writing so the tag existing data is stale. */
 	tag->read_cache_expire = (uint64_t)0;


### PR DESCRIPTION
I ran cppcheck on the lib folder and these turned up as possible null dereferences. As we discussed, null is already checked properly higher up in the call chain already, but just fixing these for correctness' sake.