### PR TITLE
Fixes from Clang's static analyzer

### DIFF
--- a/examples/multithread_plc5_dhp.c
+++ b/examples/multithread_plc5_dhp.c
@@ -311,11 +311,6 @@ void thread_func(void *data)
         sleep_ms(100+random_min_max(0,100));
     }
 
-    if(tag) {
-        fprintf(stderr,"Thread %d done but tag still not destroyed.\n",tid);
-        plc_tag_destroy(tag);
-    }
-
     fprintf(stderr,"Thread %d completed work.\n",tid);
 
     mark_done(&done[tid]);

--- a/lib/ab/eip_dhp_pccc.c
+++ b/lib/ab/eip_dhp_pccc.c
@@ -308,13 +308,6 @@ int eip_dhp_pccc_tag_write_start(ab_tag_p tag)
 	mem_copy(data,tag->encoded_name,tag->encoded_name_size);
 	data += tag->encoded_name_size;
 
-	/* point to the end of the struct */
-	data = (req->data) + sizeof(pccc_dhp_co_req);
-
-	/* copy laa into the request */
-	mem_copy(data,tag->encoded_name,tag->encoded_name_size);
-	data += tag->encoded_name_size;
-
 	/* What type and size do we have? */
 	if(tag->elem_size != 2 && tag->elem_size != 4) {
 		pdebug(debug,"Unsupported data type size: %d",tag->elem_size);


### PR DESCRIPTION
In examples\multithread_plc5_dhp.c: this block will never be true as tag
is set to NULL in the while loop beforehand.

In lib\ab\eip_dhp_pccc.c: the deleted block is an exact duplicate of the
previous set of lines. Encoded name is being copied into data twice and
data is incremented twice incorrectly (correct me on this if I'm wrong)