### PR TITLE
honor LIB_SUFFIX if set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,6 @@ target_link_libraries (simple_cpp ${example_LIBRARIES} )
 CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/libplctag.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/libplctag.pc" @ONLY)
 
 # for installation
-install(TARGETS plctag DESTINATION lib)
+install(TARGETS plctag DESTINATION lib${LIB_SUFFIX})
 install(FILES "${lib_SRC_PATH}/libplctag.h" DESTINATION include)
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libplctag.pc" DESTINATION "lib/pkgconfig")
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libplctag.pc" DESTINATION "lib${LIB_SUFFIX}/pkgconfig")


### PR DESCRIPTION
many Linux distributions use this variable to change the shared library
destination for 64bit build to be sure that the files are in the right
place and to make possible to have 32/64 bit parallel installation.