### PR TITLE
Add PCCC-Read support to LGX class controllers 

### DIFF
--- a/src/protocols/ab/cip.c
+++ b/src/protocols/ab/cip.c
@@ -279,6 +279,8 @@ int cip_encode_path(ab_tag_p tag, const char *path)
         tag->dhp_src  = 0;
         tag->dhp_dest = 0;
         tag->use_dhp_direct = 0;
+        tag->use_ucmm = 1;
+        pdebug(DEBUG_INFO,"No DH+ Path and no Micro800 detected, falling back to LGX-UCMM-packets");
     } else {
         /* we had the special DH+ format and it was
          * either not last or not a PLC5/SLC.  That

--- a/src/protocols/ab/defs.h
+++ b/src/protocols/ab/defs.h
@@ -906,7 +906,6 @@ START_PACK typedef struct {
 } END_PACK pccc_req;
 
 
-
 START_PACK typedef struct {
     /* encap header */
     uint16_le encap_command;         /* ALWAYS 0x006f Unconnected Send*/
@@ -1049,4 +1048,58 @@ START_PACK typedef struct {
     //uint8_t pccc_data[ZLA_SIZE];    /* data for PCCC response. */
 } END_PACK pccc_dhp_resp;
 
+START_PACK typedef struct {
+    /* encap header */
+    uint16_le encap_command;         /* ALWAYS 0x006f Unconnected Send*/
+    uint16_le encap_length;          /* packet size in bytes - 24 */
+    uint32_le encap_session_handle;  /* from session set up */
+    uint32_le encap_status;          /* always _sent_ as 0 */
+    uint64_le encap_sender_context;  /* whatever we want to set this to, used for
+                                     * identifying responses when more than one
+                                     * are in flight at once.
+                                     */
+    uint32_le encap_options;         /* 0, reserved for future use */
 
+    /* Interface Handle etc. */
+    uint32_le interface_handle;      /* ALWAYS 0 */
+    uint16_le router_timeout;        /* in seconds, 5 or 10 seems to be good.*/
+
+    /* Common Packet Format - CPF Unconnected */
+    uint16_le cpf_item_count;        /* ALWAYS 2 */
+    uint16_le cpf_nai_item_type;     /* ALWAYS 0 */
+    uint16_le cpf_nai_item_length;   /* ALWAYS 0 */
+    uint16_le cpf_udi_item_type;     /* ALWAYS 0x00B2 - Unconnected Data Item */
+    uint16_le cpf_udi_item_length;   /* REQ: fill in with length of remaining data. */
+
+    /* CM Service Request - Connection Manager */
+    /* NOTE, we overlay the following if this is PCCC */
+    uint8_t cm_service_code;        /* ALWAYS 0x52 Unconnected Send */
+    uint8_t cm_req_path_size;       /* ALWAYS 2, size in words of path, next field */
+    uint8_t cm_req_path[4];         /* ALWAYS 0x20,0x06,0x24,0x01 for CM, instance 1*/
+
+    /* Unconnected send */
+    uint8_t secs_per_tick;          /* seconds per tick */
+    uint8_t timeout_ticks;          /* timeout = src_secs_per_tick * src_timeout_ticks */
+
+    /* size ? */
+    uint16_le uc_cmd_length;         /* length of embedded packet */
+
+    /* PCCC Command Req Routing */
+    uint8_t service_code;           /* ALWAYS 0x4B, Execute PCCC */
+    uint8_t req_path_size;          /* ALWAYS 0x02, in 16-bit words */
+    uint8_t req_path[4];            /* ALWAYS 0x20,0x67,0x24,0x01 for PCCC */
+    uint8_t request_id_size;        /* ALWAYS 7 */
+    uint16_le vendor_id;             /* Our CIP Vendor ID */
+    uint32_le vendor_serial_number;  /* Our CIP Vendor Serial Number */
+
+    /* PCCC Command */
+    uint8_t pccc_command;           /* CMD read, write etc. */
+    uint8_t pccc_status;            /* STS 0x00 in request */
+    uint16_le pccc_seq_num;          /* TNS transaction/sequence id */
+    uint8_t pccc_function;          /* FNC sub-function of command */
+    uint16_le pccc_offset;           /* offset of requested in total request */
+    uint16_le pccc_transfer_size;    /* total number of words requested */
+    //uint8_t pccc_data[ZLA_SIZE];   /* send_data for request */
+
+    /* IOI path to LGX-PLC */
+} END_PACK pccc_ucmm_req;

--- a/src/protocols/ab/eip_pccc.h
+++ b/src/protocols/ab/eip_pccc.h
@@ -32,6 +32,8 @@
 /* PCCC */
 int eip_pccc_tag_status(ab_tag_p tag);
 int eip_pccc_tag_read_start(ab_tag_p tag);
+int eip_pccc_tag_read_start_standard(ab_tag_p tag);
+int eip_pccc_tag_read_start_ucmm(ab_tag_p tag);
 int eip_pccc_tag_write_start(ab_tag_p tag);
 
 

--- a/src/protocols/ab/tag.h
+++ b/src/protocols/ab/tag.h
@@ -52,6 +52,7 @@ struct ab_tag_t {
     /* how do we talk to this device? */
     int protocol_type;
     int use_dhp_direct;
+    int use_ucmm;
     uint8_t dhp_src;
     uint8_t dhp_dest;
 


### PR DESCRIPTION
Hi Kyle, as discussed in the corresponding issue, here is how I patched the library. Take a look at what you might do differently, I looked at eip_cip.c for reference, maybe there is a cleaner way to integrate the separation of UCMM and standard packages...