### PR TITLE
Prevent uninitialized variable reference in stress_api_lock.c

### DIFF
--- a/src/examples/stress_api_lock.c
+++ b/src/examples/stress_api_lock.c
@@ -81,7 +81,7 @@ void *test_tag(void *data)
 
     while(!done) {
         int rc = PLCTAG_STATUS_OK;
-        int32_t value;
+        int32_t value = 0;
         int64_t start;
         int64_t end;
 


### PR DESCRIPTION
if rc != PLCTAG_STATUS_OK (line 94), then the variable 'value' will be uninitialized and is still referenced by the fprintf call on line 117. Clang spit up about this when I was compiling on Termux.